### PR TITLE
sgm-86: add remote config for app version and maintenance checks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         applicationId = "io.kikiriki.sgmovie"
         minSdk = 23
         targetSdk = 35
-        versionCode = 20240327
+        versionCode = 20250327
         versionName = "1.2.0"
 
         /* we will use the custom test runner which support hilt */

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/AppConfig.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/AppConfig.kt
@@ -1,0 +1,6 @@
+package io.kikiriki.sgmovie.ui.main
+
+data class AppConfig(
+    val minAppVersion: Long,
+    val isMaintenance: Boolean
+)

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainViewModel.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainViewModel.kt
@@ -9,6 +9,7 @@ import io.kikiriki.sgmovie.analytics.AnalyticEvent
 import io.kikiriki.sgmovie.analytics.AnalyticsService
 import io.kikiriki.sgmovie.domain.model.Movie
 import io.kikiriki.sgmovie.domain.model.base.GResult
+import io.kikiriki.sgmovie.domain.preferences.RemoteConfig
 import io.kikiriki.sgmovie.domain.usecase.GetMoviesUseCase
 import io.kikiriki.sgmovie.domain.usecase.UpdateMovieLikeUseCase
 import io.kikiriki.sgmovie.model.Sort
@@ -22,11 +23,23 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val getMoviesUseCase: GetMoviesUseCase,
     private val updateMovieLikeUseCase: UpdateMovieLikeUseCase,
-    private val analyticsService: AnalyticsService
+    private val analyticsService: AnalyticsService,
+    private val remoteConfig: RemoteConfig
 ) : ViewModel() {
 
     private val _uiState: MutableLiveData<MainUIState> = MutableLiveData(MainUIState())
     val uiState: LiveData<MainUIState> = _uiState
+
+    private val _appConfig = MutableLiveData<AppConfig>()
+    val appConfig: LiveData<AppConfig> = _appConfig
+
+    fun getAppConfig() = viewModelScope.launch {
+        _uiState.postValue(MainUIState(isLoading = true))
+        _appConfig.postValue(AppConfig(
+            minAppVersion = remoteConfig.getMinAppVersion(),
+            isMaintenance = remoteConfig.isMaintenanceEnabled()
+        ))
+    }
 
     fun getMovies() = viewModelScope.launch {
         _uiState.postValue(MainUIState(isLoading = true))

--- a/app/src/main/java/io/kikiriki/sgmovie/utils/extension/ContextExtensions.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/utils/extension/ContextExtensions.kt
@@ -1,0 +1,13 @@
+package io.kikiriki.sgmovie.utils.extension
+
+import android.content.Context
+import androidx.core.content.pm.PackageInfoCompat
+
+fun Context.getVersionCode(): Long {
+    return try {
+        val packageInfo = packageManager.getPackageInfo(packageName, 0)
+        PackageInfoCompat.getLongVersionCode(packageInfo)
+    } catch (e: Exception) {
+        0
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Filme sortieren</string>
     <string name="main_menu_lbl_settings">Einstellungen</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Neue Version verfügbar</string>
+    <string name="dialog_update_message">Eine neue Version der App ist verfügbar. Aktualisieren Sie die App, um sie weiterhin nutzen zu können.</string>
+    <string name="dialog_update_btn_update">Aktualisieren</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Wartung</string>
+    <string name="dialog_maintenance_message">Die App wird gewartet. Bitte versuchen Sie es später erneut.</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Einstellungen</string>
     <string name="settings_lbl_version">App-Version: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Ordenar películas</string>
     <string name="main_menu_lbl_settings">Ajustes</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Nueva versión disponible</string>
+    <string name="dialog_update_message">Hay una nueva versión de la aplicación disponible. Actualízala para seguir usándola</string>
+    <string name="dialog_update_btn_update">Actualizar</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Mantenimiento</string>
+    <string name="dialog_maintenance_message">La aplicación está en mantenimiento. Inténtalo de nuevo más tarde</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Ajustes</string>
     <string name="settings_lbl_version">Version: %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Trier les films</string>
     <string name="main_menu_lbl_settings">Paramètres</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Nouvelle version disponible</string>
+    <string name="dialog_update_message">Une nouvelle version de l\'application est disponible. Effectuez une mise à jour pour continuer à l\'utiliser.</string>
+    <string name="dialog_update_btn_update">Mise à jour</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Maintenance</string>
+    <string name="dialog_maintenance_message">L\'application est en cours de maintenance. Veuillez réessayer ultérieurement.</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Paramètres</string>
     <string name="settings_lbl_version">Version de l\'application : %1$s</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Urutkan film</string>
     <string name="main_menu_lbl_settings">Pengaturan</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Versi baru tersedia</string>
+    <string name="dialog_update_message">Versi baru aplikasi tersedia. Perbarui untuk terus menggunakannya</string>
+    <string name="dialog_update_btn_update">Pembaruan</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Pemeliharaan</string>
+    <string name="dialog_maintenance_message">Aplikasi sedang dalam pemeliharaan. Silakan coba lagi nanti</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Pengaturan</string>
     <string name="settings_lbl_version">Versi aplikasi: %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Ordina filmati</string>
     <string name="main_menu_lbl_settings">Impostazioni</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Nuova versione disponibile</string>
+    <string name="dialog_update_message">È disponibile una nuova versione dell\'app. Aggiorna per continuare a usarla</string>
+    <string name="dialog_update_btn_update">Aggiorna</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Manutenzione</string>
+    <string name="dialog_maintenance_message">L\'app è in manutenzione. Riprova più tardi</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Impostazioni</string>
     <string name="settings_lbl_version">Versione app: %1$s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Classificar filmes</string>
     <string name="main_menu_lbl_settings">Definições</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Nova versão disponível</string>
+    <string name="dialog_update_message">Uma nova versão do aplicativo está disponível. Atualize para continuar usando-o</string>
+    <string name="dialog_update_btn_update">Atualizar</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Manutenção</string>
+    <string name="dialog_maintenance_message">O aplicativo está em manutenção. Tente novamente mais tarde</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Definições</string>
     <string name="settings_lbl_version">Versão da aplicação: %1$s</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Pagbukud-bukurin ang mga pelikula</string>
     <string name="main_menu_lbl_settings">Mga Setting</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">Available ang bagong bersyon</string>
+    <string name="dialog_update_message">May available na bagong bersyon ng app. I-update upang magpatuloy sa paggamit nito</string>
+    <string name="dialog_update_btn_update">I-update</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Pagpapanatili</string>
+    <string name="dialog_maintenance_message">Ang app ay nasa ilalim ng maintenance. Pakisubukang muli mamaya</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Mga Setting</string>
     <string name="settings_lbl_version">Bersyon ng app: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,15 @@
     <string name="main_menu_lbl_sort">Sort movies</string>
     <string name="main_menu_lbl_settings">Settings</string>
 
+    <!-- UPDATE DIALOG -->
+    <string name="dialog_update_title">New version available</string>
+    <string name="dialog_update_message">A new version of the app is available. Update to continue using it</string>
+    <string name="dialog_update_btn_update">Update</string>
+
+    <!-- MAINTENANCE DIALOG -->
+    <string name="dialog_maintenance_title">Maintenance</string>
+    <string name="dialog_maintenance_message">The app is under maintenance. Please, try again later</string>
+
     <!-- SETTINGS ACTIVITY -->
     <string name="settings_title">Settings</string>
     <string name="settings_lbl_version">App version: %1$s</string>

--- a/app/src/test/java/io/kikiriki/sgmovie/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/io/kikiriki/sgmovie/ui/main/MainViewModelTest.kt
@@ -7,6 +7,7 @@ import io.kikiriki.sgmovie.data.exception.LocalDataSourceException
 import io.kikiriki.sgmovie.data.exception.RemoteDataSourceException
 import io.kikiriki.sgmovie.domain.model.Movie
 import io.kikiriki.sgmovie.domain.model.base.GResult
+import io.kikiriki.sgmovie.domain.preferences.RemoteConfig
 import io.kikiriki.sgmovie.domain.usecase.GetMoviesUseCase
 import io.kikiriki.sgmovie.domain.usecase.UpdateMovieLikeUseCase
 import io.mockk.coEvery
@@ -21,6 +22,7 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class MainViewModelTest : BaseTest() {
 
+    @RelaxedMockK private lateinit var remoteConfig: RemoteConfig
     @RelaxedMockK private lateinit var analyticsService: AnalyticsService
     @RelaxedMockK private lateinit var getMoviesUseCase: GetMoviesUseCase
     @RelaxedMockK private lateinit var updateMovieLikeUseCase: UpdateMovieLikeUseCase
@@ -29,7 +31,8 @@ class MainViewModelTest : BaseTest() {
 
     override fun onStart() {
         super.onStart()
-        mainViewModel = MainViewModel(getMoviesUseCase, updateMovieLikeUseCase, analyticsService)
+        mainViewModel = MainViewModel(getMoviesUseCase, updateMovieLikeUseCase,
+            analyticsService, remoteConfig)
     }
 
     @Test


### PR DESCRIPTION
This commit introduces remote configuration capabilities to the application, allowing for dynamic control over app behavior based on server-side settings. Specifically, it adds functionality to check the minimum required app version and whether the app is under maintenance.

New Features:
- Implemented `AppConfig` data class to hold configuration values.
- Added `getAppConfig()` function in `MainViewModel` to fetch the minimum app version and maintenance status from remote config.
- Integrated `RemoteConfig` to retrieve configuration values.
- Added extension function `getVersionCode()` to get the app version code.
- Added dialogs to handle update prompts and maintenance notifications.

Enhancements:
- Modified `MainActivity` to retrieve and process app configuration on startup.
- Added observers in `MainActivity` to handle app configuration changes, and display appropriate dialogs for updates or maintenance.

Localization:
- Added strings for update and maintenance dialogs in multiple languages: English, Spanish, French, German, Italian, Portuguese, Indonesian, and Tagalog.