### PR TITLE
sgm-84: minimice request to firestore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.livedata)
     implementation(libs.androidx.lifecycle.runtime)
+    // android X: worker
+    implementation(libs.androidx.work.runtime.ktx)
 
     // google material
     implementation(libs.google.material)
@@ -77,6 +79,8 @@ dependencies {
     // hilt - dependency injector
     implementation(libs.hilt)
     kapt(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.work)
+    kapt(libs.androidx.hilt.compiler)
 
     // testing
     testImplementation(libs.test.junit)

--- a/app/src/androidTest/java/io/kikiriki/sgmovie/di/FakeMovieFirestoreDataSourceImpl.kt
+++ b/app/src/androidTest/java/io/kikiriki/sgmovie/di/FakeMovieFirestoreDataSourceImpl.kt
@@ -15,10 +15,6 @@ class FakeMovieFirestoreDataSourceImpl @Inject constructor() : MovieFirestoreDat
 
     override suspend fun getLikes(): Map<String, Long> = storedLikes
 
-    override fun getMovieLikesById(movieId: String): Flow<Long> {
-        return flowOf(1)
-    }
-
     override fun updateLike(movieId: String, like: Boolean) {
         if(storedLikes.containsKey(movieId)) {
             val actualLikes = storedLikes[movieId] ?: 0

--- a/app/src/androidTest/java/io/kikiriki/sgmovie/di/FakeMovieFirestoreDataSourceImpl.kt
+++ b/app/src/androidTest/java/io/kikiriki/sgmovie/di/FakeMovieFirestoreDataSourceImpl.kt
@@ -7,23 +7,24 @@ import javax.inject.Inject
 
 class FakeMovieFirestoreDataSourceImpl @Inject constructor() : MovieFirestoreDataSource {
 
-    private val moviesLike = hashMapOf<String, Long>(
-        "some-id" to 3,
-        "another-id" to 1
+    private val storedLikes = mutableMapOf(
+        "758bf02e-3122-46e0-884e-67cf83df1786" to 4L,
+        "dc2e6bd1-8156-4886-adff-b39e6043af0c" to 2L,
+        "58611129-2dbc-4a81-a72f-77ddfc1b1b49" to 3L
     )
 
-    override fun getLikes(): Flow<Map<String, Long>> = flowOf(moviesLike)
+    override suspend fun getLikes(): Map<String, Long> = storedLikes
 
     override fun getMovieLikesById(movieId: String): Flow<Long> {
         return flowOf(1)
     }
 
     override fun updateLike(movieId: String, like: Boolean) {
-        if(moviesLike.containsKey(movieId)) {
-            val actualLikes = moviesLike[movieId] ?: 0
-            moviesLike[movieId] = actualLikes + (if (like) 1 else -1)
+        if(storedLikes.containsKey(movieId)) {
+            val actualLikes = storedLikes[movieId] ?: 0
+            storedLikes[movieId] = actualLikes + (if (like) 1 else -1)
         } else {
-            moviesLike[movieId] = 1
+            storedLikes[movieId] = 1
         }
     }
 }

--- a/app/src/androidTest/java/io/kikiriki/sgmovie/ui/main/MainActivityUITest.kt
+++ b/app/src/androidTest/java/io/kikiriki/sgmovie/ui/main/MainActivityUITest.kt
@@ -25,6 +25,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.work.WorkerFactory
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.kikiriki.sgmovie.R
@@ -38,6 +39,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Inject
 
 
 @HiltAndroidTest
@@ -45,6 +47,9 @@ class MainActivityUITest {
 
     @get:Rule(order = 0)
     var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var workerFactory: WorkerFactory
 
     @get:Rule(order = 1)
     var activityRule: ActivityScenarioRule<MainActivity> = ActivityScenarioRule(MainActivity::class.java)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,12 @@
         android:theme="@style/AppTheme"
         tools:targetApi="31" >
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove">
+        </provider>
+
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true">

--- a/app/src/main/java/io/kikiriki/sgmovie/MyApplication.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/MyApplication.kt
@@ -1,7 +1,22 @@
 package io.kikiriki.sgmovie
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class MyApplication : Application()
+class MyApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+
+}

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainActivity.kt
@@ -8,6 +8,9 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.isVisible
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import coil.load
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.badge.BadgeUtils
@@ -24,6 +27,7 @@ import io.kikiriki.sgmovie.ui.movie_detail.MovieDetailFragment
 import io.kikiriki.sgmovie.ui.settings.SettingsActivity
 import io.kikiriki.sgmovie.utils.CoilUtils
 import io.kikiriki.sgmovie.utils.extension.getVersionCode
+import io.kikiriki.sgmovie.workers.FirebaseSyncWorker
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -44,6 +48,21 @@ class MainActivity : BaseActivity() {
         setupView()
 
         viewModel.getAppConfig()
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        val workRequest = OneTimeWorkRequestBuilder<FirebaseSyncWorker>()
+            .addTag("firebase_sync")
+            .build()
+
+        WorkManager.getInstance(this).enqueueUniqueWork("FirebaseSync", ExistingWorkPolicy.KEEP, workRequest)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        WorkManager.getInstance(this).cancelAllWorkByTag("firebase_sync")
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainActivity.kt
@@ -54,15 +54,17 @@ class MainActivity : BaseActivity() {
         super.onStart()
 
         val workRequest = OneTimeWorkRequestBuilder<FirebaseSyncWorker>()
-            .addTag("firebase_sync")
+            .addTag(FirebaseSyncWorker.WORKER_NAME)
             .build()
 
-        WorkManager.getInstance(this).enqueueUniqueWork("FirebaseSync", ExistingWorkPolicy.KEEP, workRequest)
+        WorkManager.getInstance(this)
+            .enqueueUniqueWork(FirebaseSyncWorker.WORKER_NAME, ExistingWorkPolicy.KEEP, workRequest)
     }
 
     override fun onPause() {
         super.onPause()
-        WorkManager.getInstance(this).cancelAllWorkByTag("firebase_sync")
+        WorkManager.getInstance(this)
+            .cancelAllWorkByTag(FirebaseSyncWorker.WORKER_NAME)
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainActivity.kt
@@ -50,21 +50,9 @@ class MainActivity : BaseActivity() {
         viewModel.getAppConfig()
     }
 
-    override fun onStart() {
-        super.onStart()
-
-        val workRequest = OneTimeWorkRequestBuilder<FirebaseSyncWorker>()
-            .addTag(FirebaseSyncWorker.WORKER_NAME)
-            .build()
-
-        WorkManager.getInstance(this)
-            .enqueueUniqueWork(FirebaseSyncWorker.WORKER_NAME, ExistingWorkPolicy.KEEP, workRequest)
-    }
-
     override fun onPause() {
         super.onPause()
-        WorkManager.getInstance(this)
-            .cancelAllWorkByTag(FirebaseSyncWorker.WORKER_NAME)
+        stopSyncLikes()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -134,6 +122,7 @@ class MainActivity : BaseActivity() {
             // list items
             viewBinding.recyclerView.isVisible = (uiState.error == null && !uiState.isLoading)
             sortMovies(uiState.items)
+            startSyncLikes()
 
             // error view
             viewBinding.errorView.root.isVisible = uiState.error != null
@@ -250,6 +239,20 @@ class MainActivity : BaseActivity() {
         startActivity(
             Intent(this, SettingsActivity::class.java)
         )
+    }
+
+    private fun startSyncLikes() {
+        val workRequest = OneTimeWorkRequestBuilder<FirebaseSyncWorker>()
+            .addTag(FirebaseSyncWorker.WORKER_NAME)
+            .build()
+
+        WorkManager.getInstance(this)
+            .enqueueUniqueWork(FirebaseSyncWorker.WORKER_NAME, ExistingWorkPolicy.KEEP, workRequest)
+    }
+
+    private fun stopSyncLikes() {
+        WorkManager.getInstance(this)
+            .cancelAllWorkByTag(FirebaseSyncWorker.WORKER_NAME)
     }
 
 }

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainViewModel.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainViewModel.kt
@@ -8,7 +8,6 @@ import io.kikiriki.sgmovie.R
 import io.kikiriki.sgmovie.analytics.AnalyticEvent
 import io.kikiriki.sgmovie.analytics.AnalyticsService
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import io.kikiriki.sgmovie.domain.preferences.RemoteConfig
 import io.kikiriki.sgmovie.domain.usecase.GetMoviesUseCase
 import io.kikiriki.sgmovie.domain.usecase.UpdateMovieLikeUseCase
@@ -45,24 +44,17 @@ class MainViewModel @Inject constructor(
         _uiState.postValue(MainUIState(isLoading = true))
 
         getMoviesUseCase()
-            .onEach {
-                when (it) {
+            .onEach { result ->
 
-                    is GResult.Success -> {
-                        val movies = it.data
+                result.fold(
+                    onSuccess = { movies ->
                         _uiState.value = MainUIState(items = movies)
-                    }
-                    is GResult.Error -> {
-                        val errorSt = ExceptionManager.getMessage(it.error)
+                    },
+                    onFailure = { error ->
+                        val errorSt = ExceptionManager.getMessage(error)
                         _uiState.value = MainUIState(error = errorSt)
                     }
-                    is GResult.SuccessWithError -> {
-                        val movies = it.data
-                        val errorSt = ExceptionManager.getMessage(it.error)
-                        _uiState.value = MainUIState(items = movies, message = errorSt)
-                    }
-
-                }
+                )
             }
             .catch {
                 val error = ExceptionManager.getMessage(it)

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainViewModel.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/main/MainViewModel.kt
@@ -72,9 +72,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun updateMovie(movie: Movie) = viewModelScope.launch {
-        val newMovieStatus = movie.copy(like = !movie.like)
-        val result = updateMovieLikeUseCase(newMovieStatus)
-        result.fold(
+        updateMovieLikeUseCase(movie).fold(
             onSuccess = { success ->
                 if (!success) {
                     _uiState.value = MainUIState(error = R.string.movie_detail_error_cannot_update_like)

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModel.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModel.kt
@@ -58,18 +58,14 @@ class MovieDetailViewModel @Inject constructor(
 
     fun updateMovieLike() = viewModelScope.launch {
         // check current movie is not null
-        var newMovieStatus = movie.value
+        val newMovieStatus = movie.value
         if (newMovieStatus == null) {
             _error.postValue(R.string.movie_detail_error_cannot_update_like)
             return@launch
         }
 
-        // switch movie like
-        newMovieStatus = newMovieStatus.copy(like = !newMovieStatus.like)
-
         // update in local and firestore
-        val result = updateMovieLikeUseCase(newMovieStatus)
-        result.fold(
+        updateMovieLikeUseCase(newMovieStatus).fold(
             onSuccess = { success ->
                 if (!success) {
                     _error.postValue(R.string.movie_detail_error_cannot_update_like)

--- a/app/src/main/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModel.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModel.kt
@@ -42,12 +42,21 @@ class MovieDetailViewModel @Inject constructor(
 
     fun getMovieById(movieId: String) = viewModelScope.launch {
         getMovieByIdUseCase(movieId)
-            .onEach { movie ->
-                _movie.postValue(movie)
-                // fetch streaming provider if are still null
-                if (_streamingProviders.value == null) {
-                    fetchStreamingProviders(movie)
-                }
+            .onEach { result ->
+
+                result.fold(
+                    onSuccess = { movie: Movie ->
+                        _movie.postValue(movie)
+                        // fetch streaming provider if are still null
+                        if (_streamingProviders.value == null) {
+                            fetchStreamingProviders(movie)
+                        }
+                    },
+                    onFailure = {
+                        val error = ExceptionManager.getMessage(it)
+                        _error.postValue(error)
+                    }
+                )
             }
             .catch {
                 val error = ExceptionManager.getMessage(it)

--- a/app/src/main/java/io/kikiriki/sgmovie/workers/FirebaseSyncWorker.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/workers/FirebaseSyncWorker.kt
@@ -29,10 +29,10 @@ class FirebaseSyncWorker @AssistedInject constructor(
 
             //seconds = remoteConfig.getFirestoreRefreshSeconds()
 
-            repository.getAllLikes().fold(
+            repository.getAllMovieLikes().fold(
                 onSuccess = { updatedLikes ->
                     println("kprint: updateLikes = $updatedLikes ")
-                    repository.updateAllLikes(updatedLikes)
+                    repository.updateAllMovieLikes(updatedLikes)
                 },
                 onFailure = { error ->
                     error.printStackTrace()

--- a/app/src/main/java/io/kikiriki/sgmovie/workers/FirebaseSyncWorker.kt
+++ b/app/src/main/java/io/kikiriki/sgmovie/workers/FirebaseSyncWorker.kt
@@ -1,0 +1,65 @@
+package io.kikiriki.sgmovie.workers
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import io.kikiriki.sgmovie.domain.preferences.RemoteConfig
+import io.kikiriki.sgmovie.domain.repository.MovieRepository
+import java.util.concurrent.TimeUnit
+
+@HiltWorker
+class FirebaseSyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val repository: MovieRepository,
+    private val remoteConfig: RemoteConfig
+) : CoroutineWorker(context, workerParams) {
+
+    private var seconds = 10L
+
+    override suspend fun doWork(): Result {
+        return try {
+
+            println("kprint: FirebaseSyncWorker: starting ")
+
+            //seconds = remoteConfig.getFirestoreRefreshSeconds()
+
+            repository.getAllLikes().fold(
+                onSuccess = { updatedLikes ->
+                    println("kprint: updateLikes = $updatedLikes ")
+                    repository.updateAllLikes(updatedLikes)
+                },
+                onFailure = { error ->
+                    error.printStackTrace()
+                }
+            )
+
+            println("kprint: FirebaseSyncWorker: success")
+
+            scheduleNextWork()
+
+            Result.success()
+        } catch (e: Exception) {
+            println("kprint: FirebaseSyncWorker: error: ${e.localizedMessage}")
+            e.printStackTrace()
+            scheduleNextWork()
+
+            Result.retry() // Reintenta si falla
+        }
+    }
+
+    private fun scheduleNextWork() {
+        println("kprint: FirebaseSyncWorker: scheduling next work in  $seconds seconds ")
+        val workRequest = OneTimeWorkRequestBuilder<FirebaseSyncWorker>()
+            .setInitialDelay(seconds, TimeUnit.SECONDS)
+            .addTag("firebase_sync") // Asigna un tag para poder cancelarlo
+            .build()
+
+        WorkManager.getInstance(applicationContext).enqueue(workRequest)
+    }
+}

--- a/app/src/test/java/io/kikiriki/sgmovie/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/io/kikiriki/sgmovie/ui/main/MainViewModelTest.kt
@@ -6,7 +6,6 @@ import io.kikiriki.sgmovie.core.test.BaseTest
 import io.kikiriki.sgmovie.data.exception.LocalDataSourceException
 import io.kikiriki.sgmovie.data.exception.RemoteDataSourceException
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import io.kikiriki.sgmovie.domain.preferences.RemoteConfig
 import io.kikiriki.sgmovie.domain.usecase.GetMoviesUseCase
 import io.kikiriki.sgmovie.domain.usecase.UpdateMovieLikeUseCase
@@ -18,6 +17,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import javax.inject.Inject
 
 @ExperimentalCoroutinesApi
 class MainViewModelTest : BaseTest() {
@@ -161,7 +161,7 @@ class MainViewModelTest : BaseTest() {
         val result = listOf<Movie>()
 
         // when
-        coEvery { getMoviesUseCase() } returns flowOf(GResult.Success(result))
+        coEvery { getMoviesUseCase() } returns flowOf(Result.success(result))
         mainViewModel.getMovies()
         delay(100)
 
@@ -213,7 +213,7 @@ class MainViewModelTest : BaseTest() {
         )
 
         // when
-        coEvery { getMoviesUseCase() } returns flowOf(GResult.Success(movies))
+        coEvery { getMoviesUseCase() } returns flowOf(Result.success(movies))
         mainViewModel.getMovies()
         delay(100)
 
@@ -251,7 +251,7 @@ class MainViewModelTest : BaseTest() {
         )
 
         // when
-        coEvery { updateMovieLikeUseCase(movie.copy(like = !movie.like)) } returns Result.failure(exception)
+        coEvery { updateMovieLikeUseCase(movie) } returns Result.failure(exception)
         mainViewModel.updateMovie(movie)
 
         // then

--- a/app/src/test/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModelTest.kt
+++ b/app/src/test/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModelTest.kt
@@ -60,7 +60,7 @@ class MovieDetailViewModelTest : BaseTest() {
 
         // when
         coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(movie)
-        coEvery { updateMovieLikeUseCase(movie.copy(like = !movie.like)) } returns Result.failure(exception)
+        coEvery { updateMovieLikeUseCase(movie) } returns Result.failure(exception)
         movieDetailViewModel.getMovieById("dc2e6bd1-8156-4886-adff-b39e6043af0c")
         movieDetailViewModel.updateMovieLike()
 

--- a/app/src/test/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModelTest.kt
+++ b/app/src/test/java/io/kikiriki/sgmovie/ui/movie_detail/MovieDetailViewModelTest.kt
@@ -59,7 +59,7 @@ class MovieDetailViewModelTest : BaseTest() {
         )
 
         // when
-        coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(movie)
+        coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(Result.success(movie))
         coEvery { updateMovieLikeUseCase(movie) } returns Result.failure(exception)
         movieDetailViewModel.getMovieById("dc2e6bd1-8156-4886-adff-b39e6043af0c")
         movieDetailViewModel.updateMovieLike()
@@ -90,10 +90,10 @@ class MovieDetailViewModelTest : BaseTest() {
         )
 
         // when
-        coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(movie)
+        coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(Result.success(movie))
         val newMovie = movie.copy(like = false)
         coEvery { updateMovieLikeUseCase(newMovie) } returns Result.success(true)
-        coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(newMovie)
+        coEvery { getMovieByIdUseCase("dc2e6bd1-8156-4886-adff-b39e6043af0c") } returns flowOf(Result.success(newMovie))
         movieDetailViewModel.getMovieById("dc2e6bd1-8156-4886-adff-b39e6043af0c")
         movieDetailViewModel.updateMovieLike()
 

--- a/data/src/main/java/io/kikiriki/sgmovie/data/di/MovieRepositoryModule.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/di/MovieRepositoryModule.kt
@@ -3,7 +3,7 @@ package io.kikiriki.sgmovie.data.di
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.components.SingletonComponent
 import io.kikiriki.sgmovie.data.repository.movie.MovieRepositoryImpl
 import io.kikiriki.sgmovie.data.repository.movie.firestore.MovieFirestoreDataSource
 import io.kikiriki.sgmovie.data.repository.movie.firestore.MovieFirestoreDataSourceImpl
@@ -16,7 +16,7 @@ import io.kikiriki.sgmovie.data.repository.movie.remote.MovieRemoteDataSourceImp
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 
 @Module
-@InstallIn(ActivityComponent::class)
+@InstallIn(SingletonComponent::class)
 abstract class MovieRepositoryModule {
 
     @Binds

--- a/data/src/main/java/io/kikiriki/sgmovie/data/model/movie/MovieLocal.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/model/movie/MovieLocal.kt
@@ -26,6 +26,8 @@ data class MovieLocal(
     val rtScore: Int,
     val coproduction: Boolean,
     var like: Boolean = false,
+    @ColumnInfo("like_count")
+    val likeCount: Long = 0,
     @ColumnInfo("tmdb_id")
     var tmdbId: String
 )

--- a/data/src/main/java/io/kikiriki/sgmovie/data/model/movie/MovieMapper.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/model/movie/MovieMapper.kt
@@ -41,6 +41,7 @@ object MovieMapper {
             runningTime = movieLocal.runningTime,
             rtScore = movieLocal.rtScore,
             coproduction = movieLocal.coproduction,
+            likeCount = movieLocal.likeCount,
             like = movieLocal.like,
             tmdbId = movieLocal.tmdbId
         )
@@ -65,6 +66,7 @@ object MovieMapper {
             rtScore = movie.rtScore,
             coproduction = movie.coproduction,
             like = movie.like,
+            likeCount  = movie.likeCount,
             tmdbId = movie.tmdbId
         )
     }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/preferences/RemoteConfigImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/preferences/RemoteConfigImpl.kt
@@ -31,12 +31,10 @@ class RemoteConfigImpl @Inject constructor(
         remoteConfig.fetchAndActivate().await()
         return remoteConfig.getBoolean(ENABLE_MAINTENANCE)
     }
-
     override suspend fun getMinAppVersion(): Long {
         remoteConfig.fetchAndActivate().await()
         return remoteConfig.getLong(MIN_APP_VERSION)
     }
-
     override suspend fun isContactEnabled(): Boolean {
         remoteConfig.fetchAndActivate().await()
         return remoteConfig.getBoolean(ENABLE_CONTACT)

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
@@ -50,8 +50,6 @@ class MovieRepositoryImpl @Inject constructor(
             local.getAsFlow().map {
                 val data = MovieMapper.localToData(it)
                 Result.success(data)
-            }.onEach {
-                println("kprint: lokoooooooh ")
             }
         )
     }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
@@ -11,11 +11,9 @@ import io.kikiriki.sgmovie.domain.model.Movie
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -69,11 +67,10 @@ class MovieRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getMovie(movieId: String): Flow<Movie> {
+    override fun getMovie(movieId: String): Flow<Result<Movie>> {
         return local.getMovieById(movieId).map {
-                MovieMapper.localToData(it)
-            }.combine(firestore.getMovieLikesById(movieId)) { movie, likeCount ->
-                movie.copy(likeCount = likeCount)
+            val data = MovieMapper.localToData(it)
+            Result.success(data)
         }
     }
 

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
@@ -28,7 +28,7 @@ class MovieRepositoryImpl @Inject constructor(
     @IODispatcher private val dispatcher: CoroutineDispatcher
 ) : MovieRepository {
 
-    override fun get(lang: String, coproductions: Boolean, forceRefresh: Boolean): Flow<GResult<List<Movie>, Throwable>> = flow {
+    override fun getMovies(lang: String, coproductions: Boolean, forceRefresh: Boolean): Flow<GResult<List<Movie>, Throwable>> = flow {
 
         // check if we need to fetch movies from API
         val localMovies = local.get()
@@ -57,9 +57,9 @@ class MovieRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun updateLike(movie: Movie): Result<Boolean> = withContext(dispatcher) {
+    override suspend fun updateMovie(movie: Movie): Result<Boolean> = withContext(dispatcher) {
         if (Constants.Repository.MOCK) {
-            return@withContext mock.updateLike(movie)
+            return@withContext mock.updateMovie(movie)
         }
 
         return@withContext try {
@@ -72,7 +72,7 @@ class MovieRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getMovieById(movieId: String): Flow<Movie> {
+    override fun getMovie(movieId: String): Flow<Movie> {
         return local.getMovieById(movieId).map {
                 MovieMapper.localToData(it)
             }.combine(firestore.getMovieLikesById(movieId)) { movie, likeCount ->
@@ -80,12 +80,12 @@ class MovieRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getAllLikes(): Result<Map<String, Long>> {
+    override suspend fun getAllMovieLikes(): Result<Map<String, Long>> {
         return try { Result.success(firestore.getLikes()) }
         catch (e: Exception) { Result.failure(e) }
     }
 
-    override suspend fun updateAllLikes(likes: Map<String, Long>): Result<Boolean> {
+    override suspend fun updateAllMovieLikes(likes: Map<String, Long>): Result<Boolean> {
         return try {
             local.updateAllLikes(likes)
             Result.success(true)

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryImpl.kt
@@ -8,7 +8,6 @@ import io.kikiriki.sgmovie.data.repository.movie.mock.MovieMockDataSource
 import io.kikiriki.sgmovie.data.repository.movie.remote.MovieRemoteDataSource
 import io.kikiriki.sgmovie.data.utils.Constants
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -28,7 +27,7 @@ class MovieRepositoryImpl @Inject constructor(
     @IODispatcher private val dispatcher: CoroutineDispatcher
 ) : MovieRepository {
 
-    override fun getMovies(lang: String, coproductions: Boolean, forceRefresh: Boolean): Flow<GResult<List<Movie>, Throwable>> = flow {
+    override fun getMovies(lang: String, coproductions: Boolean, forceRefresh: Boolean): Flow<Result<List<Movie>>> = flow {
 
         // check if we need to fetch movies from API
         val localMovies = local.get()
@@ -37,10 +36,10 @@ class MovieRepositoryImpl @Inject constructor(
             // fetch movies from api and store in room
             fetchMovies(lang, coproductions).fold(
                 onSuccess = { movies: List<Movie> ->
-                    emit(GResult.Success(movies))
+                    emit(Result.success(movies))
                 },
                 onFailure = { error: Throwable ->
-                    emit(GResult.Error(error))
+                    emit(Result.failure(error))
                     return@flow
                 }
             )
@@ -50,7 +49,7 @@ class MovieRepositoryImpl @Inject constructor(
         emitAll(
             local.getAsFlow().map {
                 val data = MovieMapper.localToData(it)
-                GResult.Success(data)
+                Result.success(data)
             }.onEach {
                 println("kprint: lokoooooooh ")
             }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/firestore/MovieFirestoreDataSource.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/firestore/MovieFirestoreDataSource.kt
@@ -3,7 +3,7 @@ package io.kikiriki.sgmovie.data.repository.movie.firestore
 import kotlinx.coroutines.flow.Flow
 
 interface MovieFirestoreDataSource {
-    fun getLikes(): Flow<Map<String, Long>>
+    suspend fun getLikes(): Map<String, Long>
     fun getMovieLikesById(movieId: String) : Flow<Long>
     fun updateLike(movieId: String, like: Boolean)
 }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/firestore/MovieFirestoreDataSource.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/firestore/MovieFirestoreDataSource.kt
@@ -1,9 +1,7 @@
 package io.kikiriki.sgmovie.data.repository.movie.firestore
 
-import kotlinx.coroutines.flow.Flow
 
 interface MovieFirestoreDataSource {
     suspend fun getLikes(): Map<String, Long>
-    fun getMovieLikesById(movieId: String) : Flow<Long>
     fun updateLike(movieId: String, like: Boolean)
 }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/firestore/MovieFirestoreDataSourceImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/firestore/MovieFirestoreDataSourceImpl.kt
@@ -3,9 +3,6 @@ package io.kikiriki.sgmovie.data.repository.movie.firestore
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -24,19 +21,6 @@ class MovieFirestoreDataSourceImpl @Inject constructor(
             doc.id to (doc.getLong(FIELD_LIKE_COUNT) ?: 0)
         }
         return likesMap
-    }
-
-    override fun getMovieLikesById(movieId: String): Flow<Long> = callbackFlow {
-        val docRef = firestore.collection(COLLECTION_MOVIES_LIKE).document(movieId)
-        val listener = docRef.addSnapshotListener { snapshot, error ->
-            if (error != null) {
-                close(error)
-                return@addSnapshotListener
-            }
-            val likeCount = snapshot?.getLong(FIELD_LIKE_COUNT) ?: 0
-            trySend(likeCount)
-        }
-        awaitClose { listener.remove() }
     }
 
     override fun updateLike(movieId: String, like: Boolean) {

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieDao.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import io.kikiriki.sgmovie.data.model.movie.MovieLocal
 import kotlinx.coroutines.flow.Flow
@@ -25,5 +26,15 @@ interface MovieDao {
 
     @Update()
     suspend fun updateMovieLike(movie: MovieLocal): Int
+
+    @Query("UPDATE movies SET like_count = :likeCount WHERE id = :movieId")
+    suspend fun updateLikes(movieId: String, likeCount: Long)
+
+    @Transaction
+    suspend fun updateMovieLikes(likes: Map<String, Long>) {
+        likes.forEach { (movieId, likeCount) ->
+            updateLikes(movieId, likeCount)
+        }
+    }
 
 }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieLocalDataSource.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieLocalDataSource.kt
@@ -7,8 +7,11 @@ interface MovieLocalDataSource {
 
     fun getAsFlow() : Flow<List<MovieLocal>>
     suspend fun get(): List<MovieLocal>
+
     fun getMovieById(movieId: String) : Flow<MovieLocal>
+
     suspend fun insert(movies: List<MovieLocal>) : Boolean
+
     suspend fun updateLike(movie: MovieLocal) : Boolean
 
     suspend fun updateAllLikes(likes: Map<String, Long>) : Boolean

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieLocalDataSource.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieLocalDataSource.kt
@@ -10,4 +10,7 @@ interface MovieLocalDataSource {
     fun getMovieById(movieId: String) : Flow<MovieLocal>
     suspend fun insert(movies: List<MovieLocal>) : Boolean
     suspend fun updateLike(movie: MovieLocal) : Boolean
+
+    suspend fun updateAllLikes(likes: Map<String, Long>) : Boolean
+
 }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieLocalDataSourceImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieLocalDataSourceImpl.kt
@@ -68,4 +68,16 @@ class MovieLocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateAllLikes(likes: Map<String, Long>): Boolean = withContext(dispatcher) {
+        return@withContext try {
+            movieDao.updateMovieLikes(likes)
+            true
+        } catch (failure: Exception) {
+            failure.printStackTrace()
+            throw LocalDataSourceException(
+                code = LocalDataSourceException.Code.CANNOT_UPDATE_MOVIE,
+                message = failure.localizedMessage.orEmpty()
+            )
+        }
+    }
 }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/mock/MovieMockDataSourceImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/mock/MovieMockDataSourceImpl.kt
@@ -3,7 +3,6 @@ package io.kikiriki.sgmovie.data.repository.movie.mock
 import io.kikiriki.sgmovie.core.coroutines.di.IODispatcher
 import io.kikiriki.sgmovie.data.exception.LocalDataSourceException
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -99,9 +98,9 @@ class MovieMockDataSourceImpl @Inject constructor(
     override fun getMovies(lang: String, coproductions: Boolean, forceRefresh: Boolean):
             Flow<Result<List<Movie>>> = flowOf(Result.success(movies))
 
-    override fun getMovie(movieId: String): Flow<Movie> {
+    override fun getMovie(movieId: String): Flow<Result<Movie>> {
         val movie = movies.find { it.id == movieId }
-        if (movie != null) return flowOf(movie)
+        if (movie != null) return flowOf(Result.success(movie))
         else throw LocalDataSourceException(LocalDataSourceException.Code.CANNOT_GET_MOVIE_DETAIL, "")
     }
 

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/mock/MovieMockDataSourceImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/mock/MovieMockDataSourceImpl.kt
@@ -15,6 +15,12 @@ class MovieMockDataSourceImpl @Inject constructor(
     @IODispatcher private val dispatcher: CoroutineDispatcher
 )  : MovieMockDataSource {
 
+    val storedLikes = mutableMapOf(
+        "758bf02e-3122-46e0-884e-67cf83df1786" to 4L,
+        "dc2e6bd1-8156-4886-adff-b39e6043af0c" to 2L,
+        "58611129-2dbc-4a81-a72f-77ddfc1b1b49" to 3L
+    )
+
     private var movies = listOf(
         Movie(
             id = "dc2e6bd1-8156-4886-adff-b39e6043af0c",
@@ -30,6 +36,7 @@ class MovieMockDataSourceImpl @Inject constructor(
             runningTime =  124,
             rtScore =  97,
             coproduction = false,
+            likeCount = storedLikes["dc2e6bd1-8156-4886-adff-b39e6043af0c"] ?: 0,
             like = true,
             tmdbId = "1123"
         ),
@@ -47,6 +54,7 @@ class MovieMockDataSourceImpl @Inject constructor(
             runningTime =  134,
             rtScore =  92,
             coproduction = false,
+            likeCount = storedLikes["0440483e-ca0e-4120-8c50-4c8cd9b965d6"] ?: 0,
             like = true,
             tmdbId = "1123"
         ),
@@ -64,6 +72,7 @@ class MovieMockDataSourceImpl @Inject constructor(
             runningTime =  86,
             rtScore =  93,
             coproduction = false,
+            likeCount = storedLikes["58611129-2dbc-4a81-a72f-77ddfc1b1b49"] ?: 0,
             like = false,
             tmdbId = "1123"
         ),
@@ -82,12 +91,13 @@ class MovieMockDataSourceImpl @Inject constructor(
             rtScore =  92,
             coproduction = false,
             like = true,
+            likeCount = storedLikes["758bf02e-3122-46e0-884e-67cf83df1786"] ?: 0,
             tmdbId = "1123"
         )
     )
 
     override fun getMovies(lang: String, coproductions: Boolean, forceRefresh: Boolean):
-            Flow<GResult<List<Movie>, Throwable>> = flowOf(GResult.Success(movies))
+            Flow<Result<List<Movie>>> = flowOf(Result.success(movies))
 
     override fun getMovie(movieId: String): Flow<Movie> {
         val movie = movies.find { it.id == movieId }
@@ -108,10 +118,15 @@ class MovieMockDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getAllMovieLikes(): Result<Map<String, Long>> {
-        TODO("Not yet implemented")
+        return Result.success(storedLikes.toMap())
     }
 
     override suspend fun updateAllMovieLikes(likes: Map<String, Long>): Result<Boolean> {
-        TODO("Not yet implemented")
+        return try {
+            storedLikes.putAll(likes)
+            Result.success(true)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/mock/MovieMockDataSourceImpl.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/mock/MovieMockDataSourceImpl.kt
@@ -86,16 +86,16 @@ class MovieMockDataSourceImpl @Inject constructor(
         )
     )
 
-    override fun get(lang: String, coproductions: Boolean, forceRefresh: Boolean):
+    override fun getMovies(lang: String, coproductions: Boolean, forceRefresh: Boolean):
             Flow<GResult<List<Movie>, Throwable>> = flowOf(GResult.Success(movies))
 
-    override fun getMovieById(movieId: String): Flow<Movie> {
+    override fun getMovie(movieId: String): Flow<Movie> {
         val movie = movies.find { it.id == movieId }
         if (movie != null) return flowOf(movie)
         else throw LocalDataSourceException(LocalDataSourceException.Code.CANNOT_GET_MOVIE_DETAIL, "")
     }
 
-    override suspend fun updateLike(movie: Movie): Result<Boolean> = withContext(dispatcher) {
+    override suspend fun updateMovie(movie: Movie): Result<Boolean> = withContext(dispatcher) {
         delay(1000)
         movies = movies.map {
             if (it.id == movie.id) {
@@ -107,4 +107,11 @@ class MovieMockDataSourceImpl @Inject constructor(
         return@withContext Result.success(true)
     }
 
+    override suspend fun getAllMovieLikes(): Result<Map<String, Long>> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun updateAllMovieLikes(likes: Map<String, Long>): Result<Boolean> {
+        TODO("Not yet implemented")
+    }
 }

--- a/data/src/test/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryTest.kt
+++ b/data/src/test/java/io/kikiriki/sgmovie/data/repository/movie/MovieRepositoryTest.kt
@@ -13,7 +13,6 @@ import io.kikiriki.sgmovie.data.repository.movie.remote.MovieRemoteDataSourceImp
 import io.kikiriki.sgmovie.data.repository.movie.util.DataMock
 import io.kikiriki.sgmovie.domain.model.Movie
 import io.kikiriki.sgmovie.domain.model.base.BaseCode
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 import io.mockk.coEvery
 import io.mockk.impl.annotations.RelaxedMockK
@@ -65,14 +64,14 @@ class MovieRepositoryTest : BaseTest() {
         coEvery { dao.getAll() } returns flowOf(DataMock.moviesLocal)
 
         // when
-        var result: GResult<List<Movie>, Throwable>? = null
-        repository.get(lang, coproductions, true).onEach {
+        var result: Result<List<Movie>>? = null
+        repository.getMovies(lang, coproductions, true).onEach {
             result = it
         }.collect()
 
         // then
-        assert( result is GResult.Success )
-        assert( (result as? GResult.Success)?.data?.isNotEmpty() == true )
+        assert( result?.isSuccess == true)
+        assert( result?.getOrNull()?.isNotEmpty() == true )
     }
 
     @Test
@@ -84,12 +83,8 @@ class MovieRepositoryTest : BaseTest() {
 
         // when
         var exception: Throwable? = null
-        repository.get(lang, coproductions).onEach {
-            when (it) {
-                is GResult.Success -> { it.data }
-                is GResult.Error -> { exception = it.error }
-                is GResult.SuccessWithError -> { exception = it.error }
-            }
+        repository.getMovies(lang, coproductions).onEach {
+            exception = it.exceptionOrNull()
         }.catch {
             exception = it
         }.collect()
@@ -108,12 +103,8 @@ class MovieRepositoryTest : BaseTest() {
 
         // when
         var exception: Throwable? = null
-        repository.get(lang, coproductions).onEach {
-            when (it) {
-                is GResult.Success -> { it.data }
-                is GResult.Error -> { exception = it.error }
-                is GResult.SuccessWithError -> { exception = it.error }
-            }
+        repository.getMovies(lang, coproductions).onEach {
+            exception = it.exceptionOrNull()
         }.catch {
             exception = it
         }.collect()
@@ -133,12 +124,8 @@ class MovieRepositoryTest : BaseTest() {
 
         // when
         var exception: Throwable? = null
-        repository.get(lang, coproductions).onEach {
-            when (it) {
-                is GResult.Success -> { it.data }
-                is GResult.Error -> { exception = it.error }
-                is GResult.SuccessWithError -> { exception = it.error }
-            }
+        repository.getMovies(lang, coproductions).onEach {
+            exception = it.exceptionOrNull()
         }.catch {
             exception = it
         }.collect()
@@ -161,12 +148,8 @@ class MovieRepositoryTest : BaseTest() {
 
         // when
         var exception: Throwable? = null
-        repository.get(lang, coproductions).onEach {
-            when (it) {
-                is GResult.Success -> { it.data }
-                is GResult.Error -> { exception = it.error }
-                is GResult.SuccessWithError -> { exception = it.error }
-            }
+        repository.getMovies(lang, coproductions).onEach {
+            exception = it.exceptionOrNull()
         }.catch {
             exception = it
         }.collect()
@@ -190,12 +173,8 @@ class MovieRepositoryTest : BaseTest() {
 
         // when
         var exception: Throwable? = null
-        val result = repository.get(lang, coproductions, true).first()
-        when (result) {
-            is GResult.Success -> { result.data }
-            is GResult.Error -> { exception = result.error }
-            is GResult.SuccessWithError -> { exception = result.error }
-        }
+        val result = repository.getMovies(lang, coproductions, true).first()
+        exception = result.exceptionOrNull()
 
         // then
         assert( exception is LocalDataSourceException)
@@ -215,7 +194,7 @@ class MovieRepositoryTest : BaseTest() {
 
         // when
         val domainMovie = MovieMapper.localToData(DataMock.moviesLocal.first())
-        val result = repository.updateLike(domainMovie)
+        val result = repository.updateMovie(domainMovie)
 
         // then
         assert( result.isFailure )
@@ -231,7 +210,7 @@ class MovieRepositoryTest : BaseTest() {
         coEvery { dao.updateMovieLike(localMovie) } returns 1
 
         // when
-        val result = repository.updateLike(movie)
+        val result = repository.updateMovie(movie)
 
         // then
         assert( result.isSuccess )

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
@@ -1,13 +1,12 @@
 package io.kikiriki.sgmovie.domain.repository
 
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import kotlinx.coroutines.flow.Flow
 
 interface MovieRepository {
 
     fun getMovies(lang: String, coproductions: Boolean = false, forceRefresh: Boolean = false):
-            Flow<GResult<List<Movie>, Throwable>>
+            Flow<Result<List<Movie>>>
 
     fun getMovie(movieId: String) : Flow<Movie>
 

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
@@ -8,7 +8,7 @@ interface MovieRepository {
     fun getMovies(lang: String, coproductions: Boolean = false, forceRefresh: Boolean = false):
             Flow<Result<List<Movie>>>
 
-    fun getMovie(movieId: String) : Flow<Movie>
+    fun getMovie(movieId: String) : Flow<Result<Movie>>
 
     suspend fun updateMovie(movie: Movie) : Result<Boolean>
 

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
@@ -6,14 +6,14 @@ import kotlinx.coroutines.flow.Flow
 
 interface MovieRepository {
 
-    fun get(lang: String, coproductions: Boolean = false, forceRefresh: Boolean = false):
-            Flow<GResult<List<Movie>, Throwable>> // TODO: refactor name to getMovies
+    fun getMovies(lang: String, coproductions: Boolean = false, forceRefresh: Boolean = false):
+            Flow<GResult<List<Movie>, Throwable>>
 
-    fun getMovieById(movieId: String) : Flow<Movie> // TODO: refactor name to getMovie
+    fun getMovie(movieId: String) : Flow<Movie>
 
-    suspend fun updateLike(movie: Movie) : Result<Boolean> // TODO: refactor name to updateMovies
+    suspend fun updateMovie(movie: Movie) : Result<Boolean>
 
-    suspend fun getAllLikes() : Result<Map<String, Long>>
+    suspend fun getAllMovieLikes() : Result<Map<String, Long>>
 
-    suspend fun updateAllLikes(likes: Map<String, Long>) : Result<Boolean>
+    suspend fun updateAllMovieLikes(likes: Map<String, Long>) : Result<Boolean>
 }

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/repository/MovieRepository.kt
@@ -7,10 +7,13 @@ import kotlinx.coroutines.flow.Flow
 interface MovieRepository {
 
     fun get(lang: String, coproductions: Boolean = false, forceRefresh: Boolean = false):
-            Flow<GResult<List<Movie>, Throwable>>
+            Flow<GResult<List<Movie>, Throwable>> // TODO: refactor name to getMovies
 
-    fun getMovieById(movieId: String) : Flow<Movie>
+    fun getMovieById(movieId: String) : Flow<Movie> // TODO: refactor name to getMovie
 
-    suspend fun updateLike(movie: Movie) : Result<Boolean>
+    suspend fun updateLike(movie: Movie) : Result<Boolean> // TODO: refactor name to updateMovies
 
+    suspend fun getAllLikes() : Result<Map<String, Long>>
+
+    suspend fun updateAllLikes(likes: Map<String, Long>) : Result<Boolean>
 }

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMovieByIdUseCase.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMovieByIdUseCase.kt
@@ -2,12 +2,10 @@ package io.kikiriki.sgmovie.domain.usecase
 
 import io.kikiriki.sgmovie.core.coroutines.di.IODispatcher
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
-import java.util.Locale
 import javax.inject.Inject
 
 class GetMovieByIdUseCase @Inject constructor(
@@ -16,7 +14,7 @@ class GetMovieByIdUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(movieId: String) : Flow<Movie> = withContext(dispatcher) {
-        return@withContext repository.getMovieById(movieId)
+        return@withContext repository.getMovie(movieId)
     }
 
 }

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMovieByIdUseCase.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMovieByIdUseCase.kt
@@ -13,7 +13,7 @@ class GetMovieByIdUseCase @Inject constructor(
     @IODispatcher private val dispatcher: CoroutineDispatcher
 ) {
 
-    suspend operator fun invoke(movieId: String) : Flow<Movie> = withContext(dispatcher) {
+    suspend operator fun invoke(movieId: String) : Flow<Result<Movie>> = withContext(dispatcher) {
         return@withContext repository.getMovie(movieId)
     }
 

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCase.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCase.kt
@@ -42,7 +42,7 @@ class GetMoviesUseCase @Inject constructor(
             preferenceStorage.setTimestampLastRequest(currentTimeMillis)
         }
 
-        return@withContext movieRepository.get(
+        return@withContext movieRepository.getMovies(
             forceRefresh = shouldRefreshData,
             lang = currentLanguage
         )

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCase.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCase.kt
@@ -20,7 +20,7 @@ class GetMoviesUseCase @Inject constructor(
 
     private val cacheTime = TimeUnit.HOURS.toMillis(12)
 
-    suspend operator fun invoke() : Flow<GResult<List<Movie>, Throwable>> = withContext(dispatcher) {
+    suspend operator fun invoke() : Flow<Result<List<Movie>>> = withContext(dispatcher) {
 
         // get saved data
         val savedLanguage = preferenceStorage.getLanguage()

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/UpdateMovieLikeUseCase.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/UpdateMovieLikeUseCase.kt
@@ -16,7 +16,7 @@ class UpdateMovieLikeUseCase @Inject constructor(
         val newLikeStatus = !movie.like
         val newLikeCountStatus = movie.likeCount + if (newLikeStatus) +1 else -1
         val newMovieStatus = movie.copy(like = newLikeStatus, likeCount = newLikeCountStatus)
-        return@withContext movieRepository.updateLike(newMovieStatus)
+        return@withContext movieRepository.updateMovie(newMovieStatus)
     }
 
 }

--- a/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/UpdateMovieLikeUseCase.kt
+++ b/domain/src/main/java/io/kikiriki/sgmovie/domain/usecase/UpdateMovieLikeUseCase.kt
@@ -13,7 +13,10 @@ class UpdateMovieLikeUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(movie: Movie) : Result<Boolean> = withContext(dispatcher) {
-        return@withContext movieRepository.updateLike(movie)
+        val newLikeStatus = !movie.like
+        val newLikeCountStatus = movie.likeCount + if (newLikeStatus) +1 else -1
+        val newMovieStatus = movie.copy(like = newLikeStatus, likeCount = newLikeCountStatus)
+        return@withContext movieRepository.updateLike(newMovieStatus)
     }
 
 }

--- a/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCaseTest.kt
+++ b/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCaseTest.kt
@@ -43,6 +43,7 @@ class GetMoviesUseCaseTest : BaseTest() {
 
         val timestamp = System.currentTimeMillis()
         val lang = Locale.getDefault().toLanguageTag()
+        coEvery { remoteConfig.getApiCacheHour() } returns 48
         coEvery { preferenceStorage.getLanguage() } returns lang
         coEvery { preferenceStorage.getTimestampLastRequest() } returns timestamp
         coEvery { movieRepository.getMovies(lang, false) } returns flowOf(Result.success(movies))
@@ -106,6 +107,7 @@ class GetMoviesUseCaseTest : BaseTest() {
         var resultData: List<Movie>? = null
         val timestamp = System.currentTimeMillis()
         val lang = Locale.getDefault().toLanguageTag()
+        coEvery { remoteConfig.getApiCacheHour() } returns 48
         coEvery { preferenceStorage.getLanguage() } returns lang
         coEvery { preferenceStorage.getTimestampLastRequest() } returns timestamp
         coEvery { movieRepository.getMovies(lang, false) } returns flowOf(Result.success(movies))

--- a/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCaseTest.kt
+++ b/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCaseTest.kt
@@ -2,7 +2,6 @@ package io.kikiriki.sgmovie.domain.usecase
 
 import io.kikiriki.sgmovie.core.test.BaseTest
 import io.kikiriki.sgmovie.domain.model.Movie
-import io.kikiriki.sgmovie.domain.model.base.GResult
 import io.kikiriki.sgmovie.domain.preferences.PreferenceStorage
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 import io.mockk.coEvery
@@ -43,13 +42,12 @@ class GetMoviesUseCaseTest : BaseTest() {
         val lang = Locale.getDefault().toLanguageTag()
         coEvery { preferenceStorage.getLanguage() } returns lang
         coEvery { preferenceStorage.getTimestampLastRequest() } returns timestamp
-        coEvery { movieRepository.get(lang, false) } returns flowOf(GResult.Success(movies))
-        getMoviesUseCase().onEach {
-            when (it) {
-                is GResult.Success -> { resultData = it.data }
-                is GResult.Error -> { resultException = it.error }
-                is GResult.SuccessWithError -> { resultException = it.error }
-            }
+        coEvery { movieRepository.getMovies(lang, false) } returns flowOf(Result.success(movies))
+        getMoviesUseCase().onEach { result ->
+            result.fold(
+                onSuccess = { resultData = it },
+                onFailure = { resultException = it }
+            )
         }.catch {
             resultException = it
         }.collect()
@@ -107,13 +105,12 @@ class GetMoviesUseCaseTest : BaseTest() {
         val lang = Locale.getDefault().toLanguageTag()
         coEvery { preferenceStorage.getLanguage() } returns lang
         coEvery { preferenceStorage.getTimestampLastRequest() } returns timestamp
-        coEvery { movieRepository.get(lang, false) } returns flowOf(GResult.Success(movies))
-        getMoviesUseCase().onEach {
-            when (it) {
-                is GResult.Success -> resultData = it.data
-                is GResult.Error -> {}
-                is GResult.SuccessWithError -> {}
-            }
+        coEvery { movieRepository.getMovies(lang, false) } returns flowOf(Result.success(movies))
+        getMoviesUseCase().onEach { result ->
+            result.fold(
+                onSuccess = { resultData = it },
+                onFailure = { resultException = it }
+            )
         }.catch {
             resultException = it
         }.collect()

--- a/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCaseTest.kt
+++ b/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/GetMoviesUseCaseTest.kt
@@ -3,6 +3,7 @@ package io.kikiriki.sgmovie.domain.usecase
 import io.kikiriki.sgmovie.core.test.BaseTest
 import io.kikiriki.sgmovie.domain.model.Movie
 import io.kikiriki.sgmovie.domain.preferences.PreferenceStorage
+import io.kikiriki.sgmovie.domain.preferences.RemoteConfig
 import io.kikiriki.sgmovie.domain.repository.MovieRepository
 import io.mockk.coEvery
 import io.mockk.impl.annotations.RelaxedMockK
@@ -20,13 +21,15 @@ import java.util.Locale
 @ExperimentalCoroutinesApi
 class GetMoviesUseCaseTest : BaseTest() {
 
+    @RelaxedMockK private lateinit var remoteConfig: RemoteConfig
     @RelaxedMockK private lateinit var movieRepository: MovieRepository
     @RelaxedMockK private lateinit var preferenceStorage: PreferenceStorage
     private lateinit var getMoviesUseCase: GetMoviesUseCase
 
     override fun onStart() {
         super.onStart()
-        getMoviesUseCase = GetMoviesUseCase(movieRepository, preferenceStorage, Dispatchers.IO)
+        getMoviesUseCase = GetMoviesUseCase(movieRepository, preferenceStorage,
+            remoteConfig, Dispatchers.IO)
     }
 
     @Test

--- a/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/UpdateMovieLikeUseCaseTest.kt
+++ b/domain/src/test/java/io/kikiriki/sgmovie/domain/usecase/UpdateMovieLikeUseCaseTest.kt
@@ -42,8 +42,12 @@ class UpdateMovieLikeUseCaseTest : BaseTest() {
             tmdbId = "1234"
         )
 
+        val newLikeStatus = !movie.like
+        val newLikeCountStatus = movie.likeCount + if (newLikeStatus) +1 else -1
+        val movieInRepository = movie.copy(like = newLikeStatus, likeCount = newLikeCountStatus)
+
         // when
-        coEvery { movieRepository.updateLike(movie) } returns Result.success(true)
+        coEvery { movieRepository.updateMovie(movieInRepository) } returns Result.success(true)
         val result = updateMovieLikeUseCase(movie)
 
         // then

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 core-ktx = "1.15.0"
 constraintlayout = "2.2.0"
 firebase-bom = "33.7.0"
+hilt-compiler = "1.2.0"
 lifecycle = "2.8.7"
 google-material = "1.12.0"
 coil = "2.4.0"
@@ -23,13 +24,17 @@ androidx-test-core = "1.6.1"
 androidx-test-espresso = "3.6.1"
 google-services = "4.4.2"
 plugin-firebase-crashlytics = "3.0.2"
+work-runtime-ktx = "2.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hilt-compiler" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hilt-compiler" }
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-livedata = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work-runtime-ktx" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-config = { module = "com.google.firebase:firebase-config" }

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ This app is made with the following libraries:
 
 * **Retrofit + Moshi:** networking
 
+* **WorkerManager:** to execute scheduled works in background
+
 * **AndroidX lifecycle:** coroutines with lifecycle aware
 
 * **Firebase:** analytics, crashlytics, firestore


### PR DESCRIPTION
In order to minimice the query to firestore (previously we have a continuous listener) we have changed the actual system (combine the flow of room with flow of firestore).

The new system will consist in a worker which will be executed every X seconds (configured by remote config) to fetch the updates from firestore, and then update in room. 

Room will continue exposing a flow, so the update to UI will be immediately.