### PR TITLE
sgm 103: create db migration

### DIFF
--- a/data/src/main/java/io/kikiriki/sgmovie/data/AppDatabase.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/AppDatabase.kt
@@ -6,7 +6,7 @@ import io.kikiriki.sgmovie.data.model.movie.MovieLocal
 import io.kikiriki.sgmovie.data.repository.movie.local.MovieDao
 
 @Database(
-    version = 3,
+    version = 4,
     entities = [MovieLocal::class]
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/data/src/main/java/io/kikiriki/sgmovie/data/di/DatabaseModule.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/di/DatabaseModule.kt
@@ -24,7 +24,8 @@ object DatabaseModule {
                 .databaseBuilder(context, AppDatabase::class.java, "sgmovie-database")
                 .addMigrations(
                     DBMigrations.MIGRATION_1_2,
-                    DBMigrations.MIGRATION_2_3
+                    DBMigrations.MIGRATION_2_3,
+                    DBMigrations.MIGRATION_3_4
                 )
                 .build()
         }

--- a/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieDao.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/repository/movie/local/MovieDao.kt
@@ -24,6 +24,9 @@ interface MovieDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(movies: List<MovieLocal>)
 
+    @Query("DELETE FROM movies")
+    suspend fun clearAll()
+
     @Update()
     suspend fun updateMovieLike(movie: MovieLocal): Int
 

--- a/data/src/main/java/io/kikiriki/sgmovie/data/utils/DBMigrations.kt
+++ b/data/src/main/java/io/kikiriki/sgmovie/data/utils/DBMigrations.kt
@@ -54,9 +54,14 @@ object DBMigrations {
         }
     }
 
-    val MIGRATION_2_3 = object : Migration(1, 2) {
+    val MIGRATION_2_3 = object : Migration(2, 3) {
         override fun migrate(db: SupportSQLiteDatabase) {
             db.execSQL("ALTER TABLE movies ADD COLUMN tmdb_id TEXT NOT NULL DEFAULT ''")
+        }
+    }
+    val MIGRATION_3_4 = object : Migration(3, 4) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE movies ADD COLUMN like_count INTEGER NOT NULL DEFAULT 0")
         }
     }
 }


### PR DESCRIPTION
This commit introduces:
* Avoid crash by creating migration to use the likeCount field.
* Avoid duplicate old movies by removing all movies before insert the new ones.
